### PR TITLE
Control panels now starts the CWD in the project directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- Increased the minimum Basilsp version to 0.4.0 (#13)
+- Increased the minimum Basilsp version to 0.4.0 (#13).
+- Control Panel now starts the nREPL server with the working directory set to the project directory (#12).
 
 ## 0.4.0
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,12 @@ The library includes an nREPL server control panel accessible in Blender’s Pro
 ![nrepl cntrl panel output - serving](misc/nrepl-ctrl-panel-running.png)
 
 The `Basilisp Project Directory` is the location where your Basilisp code resides.
-Upon starting the server, this directory is added to `sys.path` for the duration of the nREPL session, allowing Basilisp code files in that directory to be seamlessly `require`'d . 
-The following files will also be created in the directory for convenience if they do not already exist:
 
+When the server starts, this directory is:
+- Set as the current working directory for the duration of the nREPL session.
+- Added to `sys.path`, allowing Basilisp code files within it to be seamlessly require'd.
+
+Additionaly, the following files will also be created in the directory for convenience if they do not already exist:
 - `basilisp.edn`: Marks the directory as a Basilisp Project for code editors.
 - `scratch.lpy`:  A Basilisp file for users to experiment with writing code.
 - `.nrepl-port`:  The port number where the nREPL server is listening. This will overwrite any existing file.

--- a/src/basilisp_blender/control_panel.lpy
+++ b/src/basilisp_blender/control_panel.lpy
@@ -37,7 +37,7 @@
                   ^{:tag (bpy.props/StringProperty
                           **
                           :name "Basilisp Project Directory"
-                          :description "An optional path to a Basilisp Project Directory, which will be added to sys.path for the duration of the nREPL session, allowing Basilisp code files in that directory to be require'd . The following files will also be created in the directory if they do not already exist:
+                          :description "An optional path to a Basilisp Project Directory, which will be added to sys.path for the duration of the nREPL session, allowing Basilisp code files in that directory to be require'd . The current working directory will also be changes to this path for the session. The following files will also be created in the directory if they do not already exist:
 
 - basilisp.edn: Marks the directory as a Basilisp Project for code editors.
 - scratch.lpy:  A Basilisp file for users to experiment with writing code.
@@ -74,8 +74,11 @@
 
         (.append sys/path path)
 
-        #(when (= (aget sys/path -1) path)
-           (.pop sys/path))))))
+        (let [cwd (os/getcwd)]
+          (os/chdir path)
+          #(when (= (aget sys/path -1) path)
+             (.pop sys/path)
+             (os/chdir cwd)))))))
 
 (defn- ctrl-make
   "Returns a new stateful nREPL control instance in the `:ready` state.

--- a/src/basilisp_blender/control_panel.lpy
+++ b/src/basilisp_blender/control_panel.lpy
@@ -37,7 +37,7 @@
                   ^{:tag (bpy.props/StringProperty
                           **
                           :name "Basilisp Project Directory"
-                          :description "An optional path to a Basilisp Project Directory, which will be added to sys.path for the duration of the nREPL session, allowing Basilisp code files in that directory to be require'd . The current working directory will also be changes to this path for the session. The following files will also be created in the directory if they do not already exist:
+                          :description "An optional path to a Basilisp Project Directory, which will be added to sys.path for the duration of the nREPL session, allowing Basilisp code files in that directory to be require'd . The current working directory will also be changed to this path for the session. The following files will also be created in the directory if they do not already exist:
 
 - basilisp.edn: Marks the directory as a Basilisp Project for code editors.
 - scratch.lpy:  A Basilisp file for users to experiment with writing code.
@@ -49,13 +49,16 @@
 
   - Adding the directory to `sys.path`.
 
+  - The curent working directory is added to the path.
+
   - Creates an empty `basilisp.edn` file to mark it as a Basilisp Project.
 
   - Creates a `scratch.lpy` for user experimentation.
 
   If `path` does not exist or is not a directory, no action is taken.
 
-  Returns a function to remove `path` from `sys.path` for cleanup."
+  Returns a function to remove `path` from `sys.path` for cleanup, and
+  restore the curent working directory."
   [path]
   (binding [*out* sys/stdout]
     (when (and path (os.path/isdir path))
@@ -76,9 +79,10 @@
 
         (let [cwd (os/getcwd)]
           (os/chdir path)
-          #(when (= (aget sys/path -1) path)
-             (.pop sys/path)
-             (os/chdir cwd)))))))
+          (fn project-dir-restore! []
+            (when (= (aget sys/path -1) path)
+              (.pop sys/path))
+            (os/chdir cwd)))))))
 
 (defn- ctrl-make
   "Returns a new stateful nREPL control instance in the `:ready` state.

--- a/tests/basilisp_blender/integration/control_panel_test.lpy
+++ b/tests/basilisp_blender/integration/control_panel_test.lpy
@@ -89,20 +89,23 @@
               (with [tmpdir (tempfile/TemporaryDirectory)]
                     {:actions
                      [{:result (doall (seq sys/path))}
+                      {:result (os/getcwd)}
                       (p/ctrl-do! ctrl-test :server-toggle! {:project-dir tmpdir})
                       (p/ctrl-do! ctrl-test :info-get)
                       {:result (doall (seq sys/path))}
+                      {:result (os/getcwd)}
                       {:result (set (os/listdir tmpdir))}
                       (p/ctrl-do! ctrl-test :server-toggle!)
-                      {:result (doall (seq sys/path))}]
+                      {:result (doall (seq sys/path))}
+                      {:result (os/getcwd)}]
 
                      :tmpdir tmpdir}))
 
             {:keys [actions tmpdir]} res
 
-            [sys-path-before [toggle-state]
-             {:keys [project-dir] :as _info} sys-path-during files-set
-             [toggle-state2] sys-path-after]
+            [sys-path-before cwd-before [toggle-state]
+             {:keys [project-dir] :as _info} sys-path-during cwd-during files-set
+             [toggle-state2] sys-path-after cwd-after]
             (map :result actions)]
 
         (is (nil? exc) exc)
@@ -115,7 +118,12 @@
         ;; the project dir was added to the sys.path during the session
         (is (= (conj (vec sys-path-before) project-dir) sys-path-during))
         ;; the sys.path was restored after the session
-        (is (= sys-path-after sys-path-before))))
+        (is (= sys-path-after sys-path-before))
+        ;; the CWD was changed during the session
+        (is (not= cwd-before cwd-during))
+        (is (= cwd-during tmpdir))
+        ;; the CWD was restored after the session
+        (is (= cwd-before cwd-after))))
 
     (testing "destroying panel"
       (let [{:keys [res]} (but/with-client-eval!


### PR DESCRIPTION
This improves compatibility with tools like clojure-mcp, which expect the nREPL server to be started in the project directory.